### PR TITLE
Add table of content for the list of rules

### DIFF
--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -4,6 +4,42 @@ This document contains a description of all rules, what they are checking for,
 as well as an examples of documents that break the rule and corrected
 versions of the examples.
 
+- [MD001 - Header levels should only increment by one level at a time](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md001---header-levels-should-only-increment-by-one-level-at-a-time)
+- [MD002 - First header should be a top level header](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md002---first-header-should-be-a-top-level-header)
+- [MD003 - Header style](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md003---header-style)
+- [MD004 - Unordered list style](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md004---unordered-list-style)
+- [MD005 - Inconsistent indentation for list items at the same level](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md005---inconsistent-indentation-for-list-items-at-the-same-level)
+- [MD006 - Consider starting bulleted lists at the beginning of the line](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md006---consider-starting-bulleted-lists-at-the-beginning-of-the-line)
+- [MD007 - Unordered list indentation](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md007---unordered-list-indentation)
+- [MD009 - Trailing spaces](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md009---trailing-spaces)
+- [MD010 - Hard tabs](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md010---hard-tabs)
+- [MD011 - Reversed link syntax](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md011---reversed-link-syntax)
+- [MD012 - Multiple consecutive blank lines](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md012---multiple-consecutive-blank-lines)
+- [MD013 - Line length](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md013---line-length)
+- [MD014 - Dollar signs used before commands without showing output](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md014---dollar-signs-used-before-commands-without-showing-output)
+- [MD018 - No space after hash on atx style header](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md018---no-space-after-hash-on-atx-style-header)
+- [MD019 - Multiple spaces after hash on atx style header](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md019---multiple-spaces-after-hash-on-atx-style-header)
+- [MD020 - No space inside hashes on closed atx style header](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md020---no-space-inside-hashes-on-closed-atx-style-header)
+- [MD021 - Multiple spaces inside hashes on closed atx style header](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md021---multiple-spaces-inside-hashes-on-closed-atx-style-header)
+- [MD022 - Headers should be surrounded by blank lines](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md022---headers-should-be-surrounded-by-blank-lines)
+- [MD023 - Headers must start at the beginning of the line](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md023---headers-must-start-at-the-beginning-of-the-line)
+- [MD024 - Multiple headers with the same content](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md024---multiple-headers-with-the-same-content)
+- [MD025 - Multiple top level headers in the same document](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md025---multiple-top-level-headers-in-the-same-document)
+- [MD026 - Trailing punctuation in header](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md026---trailing-punctuation-in-header)
+- [MD027 - Multiple spaces after blockquote symbol](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md027---multiple-spaces-after-blockquote-symbol)
+- [MD028 - Blank line inside blockquote](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md028---blank-line-inside-blockquote)
+- [MD029 - Ordered list item prefix](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md029---ordered-list-item-prefix)
+- [MD030 - Spaces after list markers](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md030---spaces-after-list-markers)
+- [MD031 - Fenced code blocks should be surrounded by blank lines](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md031---fenced-code-blocks-should-be-surrounded-by-blank-lines)
+- [MD032 - Lists should be surrounded by blank lines](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md032---lists-should-be-surrounded-by-blank-lines)
+- [MD033 - Inline HTML](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md033---inline-html)
+- [MD034 - Bare URL used](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md034---bare-url-used)
+- [MD035 - Horizontal rule style](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md035---horizontal-rule-style)
+- [MD036 - Emphasis used instead of a header](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md036---emphasis-used-instead-of-a-header)
+- [MD037 - Spaces inside emphasis markers](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md037---spaces-inside-emphasis-markers)
+- [MD038 - Spaces inside code span elements](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md038---spaces-inside-code-span-elements)
+- [MD039 - Spaces inside link text](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md039---spaces-inside-link-text)
+
 ## MD001 - Header levels should only increment by one level at a time
 
 Tags: headers


### PR DESCRIPTION
Ruby one-liner used to generate it:

puts `mdl -l`.lines[1..-1].map { |l| "- [#{l.strip}](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md##{l.strip.downcase.gsub(/[^0-9a-z]/, '-')})" }